### PR TITLE
make sure we ignore documents that are "invalid" due to exclude list.

### DIFF
--- a/pkg/processor/api/storage.go
+++ b/pkg/processor/api/storage.go
@@ -59,7 +59,28 @@ func GenerateThumbnailStoragePath(storagePath string) string {
 	return storagePath
 }
 
-func GetFile(apiEndpoint *url.URL, storageBucket string, storagePath string, outputDirectory string) (string, error) {
+//File CRUD Operations
+func CreateFile(apiEndpoint *url.URL, storageBucket string, storagePath string, localFilepath string) error {
+
+	localFile, err := os.Open(localFilepath)
+	if err != nil {
+		return err
+	}
+	defer localFile.Close()
+
+	//manipulate the path
+	apiEndpoint.Path = fmt.Sprintf("/api/v1/storage/%s/%s", storageBucket, storagePath)
+
+	resp, err := http.Post(apiEndpoint.String(), "binary/octet-stream", localFile)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func ReadFile(apiEndpoint *url.URL, storageBucket string, storagePath string, outputDirectory string) (string, error) {
 
 	//secureProtocol := apiEndpoint.Scheme == "https"
 	//
@@ -94,22 +115,11 @@ func GetFile(apiEndpoint *url.URL, storageBucket string, storagePath string, out
 	return localFilepath, err
 }
 
-func UploadFile(apiEndpoint *url.URL, storageBucket string, storagePath string, localFilepath string) error {
-
-	localFile, err := os.Open(localFilepath)
-	if err != nil {
-		return err
-	}
-	defer localFile.Close()
+func DeleteFile(apiEndpoint *url.URL, storageBucket string, storagePath string) error {
 
 	//manipulate the path
 	apiEndpoint.Path = fmt.Sprintf("/api/v1/storage/%s/%s", storageBucket, storagePath)
 
-	resp, err := http.Post(apiEndpoint.String(), "binary/octet-stream", localFile)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return nil
+	_, err := http.NewRequest(http.MethodDelete, apiEndpoint.String(), nil)
+	return err
 }

--- a/pkg/processor/common.go
+++ b/pkg/processor/common.go
@@ -1,0 +1,14 @@
+package processor
+
+import "os"
+
+type CommonProcessor struct{}
+
+func (c *CommonProcessor) IsEmptyFile(filepath string) bool {
+	fi, err := os.Stat(filepath)
+	if err != nil {
+		return false //error occurred while attempting to read file info, just assume this file is not empty.
+	}
+	// get the size
+	return fi.Size() == 0
+}


### PR DESCRIPTION
make sure we ignore documents whose size == 0
when "delete" messages are present in the thumbnail queue, we should correctly delete the associated thumbnail.