### PR TITLE
Option to override OCR language

### DIFF
--- a/cmd/document-processor/document-processor.go
+++ b/cmd/document-processor/document-processor.go
@@ -84,6 +84,7 @@ func main() {
 						c.String("elasticsearch-endpoint"),
 						c.String("elasticsearch-index"),
 						c.String("elasticsearch-mapping"),
+						c.String("ocr-language"),
 					)
 
 					if err != nil {
@@ -125,6 +126,13 @@ func main() {
 						Usage: "Path to elasticsearch mapping file. Can be used to override static/document-processor/settings.json",
 						Value: "",
 					},
+
+					&cli.StringFlag{
+						Name:  "ocr-language",
+						Usage: "OCR language override for Tika requests",
+						Value: "",
+					},
+
 					&cli.StringFlag{
 						Name:  "amqp-url",
 						Usage: "The amqp connection string",

--- a/pkg/processor/document/document.go
+++ b/pkg/processor/document/document.go
@@ -39,12 +39,13 @@ type DocumentProcessor struct {
 	elasticsearchEndpoint        *url.URL
 	elasticsearchIndex           string
 	elasticsearchMappingOverride string
+	ocrLanguageOverride          string
 	elasticsearchClient          *elasticsearch.Client
 	filter                       *model.Filter
 	logger                       *logrus.Entry
 }
 
-func CreateDocumentProcessor(logger *logrus.Entry, apiEndpoint string, storageThumbnailBucket string, tikaEndpoint string, elasticsearchEndpoint string, elasticsearchIndex string, elasticsearchMapping string) (DocumentProcessor, error) {
+func CreateDocumentProcessor(logger *logrus.Entry, apiEndpoint string, storageThumbnailBucket string, tikaEndpoint string, elasticsearchEndpoint string, elasticsearchIndex string, elasticsearchMapping string, ocrLanguageOverride string) (DocumentProcessor, error) {
 
 	apiEndpointUrl, err := url.Parse(apiEndpoint)
 	if err != nil {
@@ -74,6 +75,7 @@ func CreateDocumentProcessor(logger *logrus.Entry, apiEndpoint string, storageTh
 		elasticsearchEndpoint:        elasticsearchEndpointUrl,
 		elasticsearchIndex:           elasticsearchIndex,
 		elasticsearchMappingOverride: elasticsearchMapping,
+		ocrLanguageOverride:          ocrLanguageOverride,
 		filter:                       &filterData,
 		logger:                       logger,
 	}
@@ -166,7 +168,7 @@ func (dp *DocumentProcessor) Process(body []byte) error {
 func (dp *DocumentProcessor) tikaHttpClient() *http.Client {
 	client := &http.Client{
 		Timeout:   time.Minute * 5, //5 minutes max to process documents.
-		Transport: TikaRoundTripper{r: http.DefaultTransport},
+		Transport: TikaRoundTripper{r: http.DefaultTransport, ocrLanguageOverride: dp.ocrLanguageOverride},
 	}
 
 	return client

--- a/pkg/processor/document/tika_client.go
+++ b/pkg/processor/document/tika_client.go
@@ -5,16 +5,25 @@ import (
 )
 
 type TikaRoundTripper struct {
-	r http.RoundTripper
+	r                   http.RoundTripper
+	ocrLanguageOverride string
 }
 
 // https://cwiki.apache.org/confluence/display/tika/TikaJAXRS#TikaJAXRS-MultipartSupport TIKA must have an Accept header to return JSON responses.
 func (mrt TikaRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if r.URL.Path == "/meta" {
 		r.Header.Add("Accept", "application/json")
+		r.Header.Add("X-Tika-OCRLanguage", "ces")
 	}
 	if r.URL.Path == "/tika" {
 		r.Header.Add("Accept", "text/plain")
+
+		if mrt.ocrLanguageOverride != "" {
+			// Note: we are not using Header#Add here because it would mess up the key
+			// Go HTTP expects all headers to be case insensitive and converts the case to avoid ambiguity.
+			// Tika on the other hand treats headers case sensitive and ignores headers with messed up case
+			r.Header["X-Tika-OCRLanguage"] = append(r.Header["X-Tika-OCRLanguage"], mrt.ocrLanguageOverride)
+		}
 	}
 
 	return mrt.r.RoundTrip(r)

--- a/pkg/processor/document/tika_client.go
+++ b/pkg/processor/document/tika_client.go
@@ -13,7 +13,6 @@ type TikaRoundTripper struct {
 func (mrt TikaRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if r.URL.Path == "/meta" {
 		r.Header.Add("Accept", "application/json")
-		r.Header.Add("X-Tika-OCRLanguage", "ces")
 	}
 	if r.URL.Path == "/tika" {
 		r.Header.Add("Accept", "text/plain")


### PR DESCRIPTION
With CLI arguments now accessible, I have added option to override OCR language as requested https://github.com/LodestoneHQ/lodestone/issues/106

You can just pass additional argument like: `--ocr-language=ces`